### PR TITLE
NCodec: new API method ncodec_utime().

### DIFF
--- a/dse/ncodec/codec.c
+++ b/dse/ncodec/codec.c
@@ -381,6 +381,50 @@ inline int64_t ncodec_tell(NCODEC* nc)
 
 
 /**
+ncodec_utime
+============
+
+Parameters
+----------
+nc (NCODEC*)
+: Network Codec object.
+
+op (NCodecUtimeOperation)
+: The UTime operation, default/zero values are ignored.
+
+Returns
+-------
+0
+: The operation was performed.
+
+-ENOSYS (-38)
+: This function is not implemented by the codec.
+
+-ENOSTR (-60)
+: The object represented by `nc` does not represent a valid stream.
+
+-ENODATA (-61)
+: Operation did not include a valid request.
+
+-ENOSR (-63)
+: No stream resource has been configured.
+*/
+inline int32_t ncodec_utime(NCODEC* nc, NCodecUtimeOperation op)
+{
+    NCodecInstance* _nc = (NCodecInstance*)nc;
+    if (_nc) {
+        if (_nc->codec.utime) {
+            return _nc->codec.utime(nc, op);
+        } else {
+            return -ENOSYS;
+        }
+    } else {
+        return -ENOSTR;
+    }
+}
+
+
+/**
 ncodec_close
 ============
 

--- a/dse/ncodec/codec.h
+++ b/dse/ncodec/codec.h
@@ -140,6 +140,12 @@ typedef struct NCodecConfigItem {
 
 typedef void NCodecMessage; /* Generic message container. */
 
+typedef struct NCodecUtimeOperation {
+    double simulation_time;
+    double step_size;
+    bool   broadcast; /* Push change to all nodes. */
+    bool   force; /* Force the change, ignore checks. Also applies to broadcast. */
+} NCodecUtimeOperation;
 
 typedef int32_t NCodecLoad(const char* filename, const char* hint);
 typedef NCODEC* NCodecOpen(const char* mime_type, NCodecStreamVTable* stream);
@@ -151,6 +157,7 @@ typedef int32_t (*NCodecWrite)(NCODEC* nc, NCodecMessage* msg);
 typedef int32_t (*NCodecRead)(NCODEC* nc, NCodecMessage* msg);
 typedef int32_t (*NCodecFlush)(NCODEC* nc);
 typedef int32_t (*NCodecTruncate)(NCODEC* nc);
+typedef int32_t (*NCodecUtime)(NCODEC* nc, NCodecUtimeOperation op);
 typedef void (*NCodecClose)(NCODEC* nc);
 
 typedef struct NCodecVTable {
@@ -160,6 +167,7 @@ typedef struct NCodecVTable {
     NCodecRead     read;
     NCodecFlush    flush;
     NCodecTruncate truncate;
+    NCodecUtime    utime;
     NCodecClose    close;
 } NCodecVTable;
 
@@ -216,5 +224,6 @@ DLL_PUBLIC int32_t          ncodec_truncate(NCODEC* nc);
 DLL_PUBLIC void             ncodec_close(NCODEC* nc);
 DLL_PUBLIC int64_t          ncodec_seek(NCODEC* nc, size_t pos, int32_t op);
 DLL_PUBLIC int64_t          ncodec_tell(NCODEC* nc);
+DLL_PUBLIC int32_t          ncodec_utime(NCODEC* nc, NCodecUtimeOperation op);
 
 #endif  // DSE_NCODEC_CODEC_H_

--- a/dse/ncodec/codec/ab/codec.c
+++ b/dse/ncodec/codec/ab/codec.c
@@ -27,6 +27,7 @@ extern int32_t pdu_write(NCODEC* nc, NCodecMessage* msg);
 extern int32_t pdu_read(NCODEC* nc, NCodecMessage* msg);
 extern int32_t pdu_flush(NCODEC* nc);
 extern int32_t pdu_truncate(NCODEC* nc);
+extern int32_t pdu_utime(NCODEC* nc, NCodecUtimeOperation op);
 
 extern void flexray_bus_model_create(ABCodecInstance* nc);
 extern void flexray_pop_bus_model_create(ABCodecInstance* nc);
@@ -367,7 +368,7 @@ NCODEC* ncodec_create(const char* mime_type)
     _nc->c.mime_type = mime_type;
 
     /* Set the default simulation step size. */
-    _nc->step_size = SIM_STEP_SIZE;
+    _nc->simulation_time.step_size = SIM_STEP_SIZE;
 
     /* Parse out the remaining parameters from the MIMEtype. */
     char* _param;
@@ -425,6 +426,7 @@ NCODEC* ncodec_create(const char* mime_type)
             .read = pdu_read,
             .flush = pdu_flush,
             .truncate = pdu_truncate,
+            .utime = pdu_utime,
             .close = codec_close,
         };
     } else {

--- a/dse/ncodec/codec/ab/codec.h
+++ b/dse/ncodec/codec/ab/codec.h
@@ -124,10 +124,11 @@ typedef struct ABCodecInstance {
     char*               trace_filename;
     FILE*               trace_file;
 
-    /* Simulation metadata. */
-    double simulation_time;
+    /* Simulation Time. */
+    double simulation_time; /* Updated after read (but before write). */
     double step_size;
     double step_size_correction;
+    double write_simulation_time; /* Set after read, use for writes. */
 } ABCodecInstance;
 
 

--- a/dse/ncodec/codec/ab/codec.h
+++ b/dse/ncodec/codec/ab/codec.h
@@ -125,10 +125,16 @@ typedef struct ABCodecInstance {
     FILE*               trace_file;
 
     /* Simulation Time. */
-    double simulation_time; /* Updated after read (but before write). */
-    double step_size;
-    double step_size_correction;
-    double write_simulation_time; /* Set after read, use for writes. */
+    struct {
+        double value; /* Updated after read (but before write). */
+        double step_size;
+        double step_size_correction;
+        double write_value; /* Set after read, use for writes. */
+        struct {
+            bool request; /* Indicates broadcast request. */
+            bool force;   /* Broadcast request with force (bypass checks). */
+        } broadcast;
+    } simulation_time;
 } ABCodecInstance;
 
 

--- a/dse/ncodec/codec/ab/flexray/flexray.c
+++ b/dse/ncodec/codec/ab/flexray/flexray.c
@@ -202,7 +202,7 @@ void flexray_bus_model_create(ABCodecInstance* nc)
     nc->reader.bus_model.log_nc = nc;
 
     /* Set the step_size (initial value, may change in operation). */
-    nc->reader.bus_model.step_size = nc->step_size;
+    nc->reader.bus_model.step_size = nc->simulation_time.step_size;
 
     /* Shallow copy the nc object. */
     ABCodecInstance* nc_copy = calloc(1, sizeof(ABCodecInstance));

--- a/dse/ncodec/codec/ab/pdu_fbs.c
+++ b/dse/ncodec/codec/ab/pdu_fbs.c
@@ -27,7 +27,7 @@ static void initialize_stream(ABCodecInstance* nc)
     flatcc_builder_t* B = &nc->fbs_builder;
     flatcc_builder_reset(B);
     ns(Stream_start_as_root_with_size(B));
-    ns(Stream_simulation_time_add(B, nc->simulation_time));
+    ns(Stream_simulation_time_add(B, nc->write_simulation_time));
     ns(Stream_pdus_start(B));
     nc->fbs_stream_initalized = true;
 }
@@ -451,6 +451,22 @@ void _reader_reset(ABCodecReader* reader)
     // clear_free_list();
 }
 
+static void _advance_simulation_time(NCODEC* nc)
+{
+    ABCodecInstance* _nc = (ABCodecInstance*)nc;
+    if (_nc == NULL) return;
+
+    /* Advance the synthesised simulation_time.
+     * (same algo as SimBus)
+     * Increment via Kahan summation.
+     * simulation_time = simulation_time + step_size;
+     */
+    double y = _nc->step_size - _nc->step_size_correction;
+    double t = _nc->simulation_time + y;
+    _nc->step_size_correction = (t - _nc->simulation_time) - y;
+    _nc->simulation_time = t;
+}
+
 
 static void get_stream_from_buffer(ABCodecReader* reader)
 {
@@ -635,6 +651,12 @@ int32_t _next_pdu(ABCodecInstance* nc, NCodecPdu* pdu)
     }
     reader->stage.model_consumed = true;
 
+    /* Increment the Simulation Time. */
+    nc->write_simulation_time =
+        nc->simulation_time; /* Calls to pdu_write use this value and not
+                                simulation_time (which will be advanced). */
+    _advance_simulation_time(nc);
+
     /* No more PDUs. */
     return -ENOMSG;
 }
@@ -681,16 +703,6 @@ int32_t pdu_truncate(NCODEC* nc)
     _nc->c.stream->seek(nc, 0, NCODEC_SEEK_RESET);
     _reader_reset(&_nc->reader);
     clear_free_list(_nc);
-
-    /* Advance the synthesised simulation_time.
-     * (same algo as SimBus)
-     * Increment via Kahan summation.
-     * simulation_time = simulation_time + step_size;
-     */
-    double y = _nc->step_size - _nc->step_size_correction;
-    double t = _nc->simulation_time + y;
-    _nc->step_size_correction = (t - _nc->simulation_time) - y;
-    _nc->simulation_time = t;
 
     return 0;
 }

--- a/dse/ncodec/codec/ab/pdu_fbs.c
+++ b/dse/ncodec/codec/ab/pdu_fbs.c
@@ -27,7 +27,7 @@ static void initialize_stream(ABCodecInstance* nc)
     flatcc_builder_t* B = &nc->fbs_builder;
     flatcc_builder_reset(B);
     ns(Stream_start_as_root_with_size(B));
-    ns(Stream_simulation_time_add(B, nc->write_simulation_time));
+    ns(Stream_simulation_time_add(B, nc->simulation_time.write_value));
     ns(Stream_pdus_start(B));
     nc->fbs_stream_initalized = true;
 }
@@ -456,15 +456,19 @@ static void _advance_simulation_time(NCODEC* nc)
     ABCodecInstance* _nc = (ABCodecInstance*)nc;
     if (_nc == NULL) return;
 
+    /* Called after reading is complete, but before truncate/write. */
+
     /* Advance the synthesised simulation_time.
      * (same algo as SimBus)
      * Increment via Kahan summation.
      * simulation_time = simulation_time + step_size;
      */
-    double y = _nc->step_size - _nc->step_size_correction;
-    double t = _nc->simulation_time + y;
-    _nc->step_size_correction = (t - _nc->simulation_time) - y;
-    _nc->simulation_time = t;
+    double y = _nc->simulation_time.step_size -
+               _nc->simulation_time.step_size_correction;
+    double t = _nc->simulation_time.value + y;
+    _nc->simulation_time.step_size_correction =
+        (t - _nc->simulation_time.value) - y;
+    _nc->simulation_time.value = t;
 }
 
 
@@ -615,7 +619,8 @@ int32_t _next_pdu(ABCodecInstance* nc, NCodecPdu* pdu)
     if (reader->stage.model_produced == false) {
         ncodec_truncate((NCODEC*)reader->bus_model.nc);
         if (reader->bus_model.vtable.progress) {
-            reader->bus_model.simulation_time = nc->simulation_time;
+            reader->bus_model.simulation_time = nc->simulation_time.value;
+            reader->bus_model.step_size = nc->simulation_time.step_size;
             reader->bus_model.vtable.progress(&reader->bus_model);
         }
         ncodec_flush((NCODEC*)reader->bus_model.nc);
@@ -651,10 +656,9 @@ int32_t _next_pdu(ABCodecInstance* nc, NCodecPdu* pdu)
     }
     reader->stage.model_consumed = true;
 
-    /* Increment the Simulation Time. */
-    nc->write_simulation_time =
-        nc->simulation_time; /* Calls to pdu_write use this value and not
-                                simulation_time (which will be advanced). */
+    /* Increment the Simulation Time.
+    Calls to pdu_write use this value and not simulation_time.value. */
+    nc->simulation_time.write_value = nc->simulation_time.value;
     _advance_simulation_time(nc);
 
     /* No more PDUs. */
@@ -704,5 +708,37 @@ int32_t pdu_truncate(NCODEC* nc)
     _reader_reset(&_nc->reader);
     clear_free_list(_nc);
 
+    if (_nc->simulation_time.broadcast.request) {
+        // TODO inject utime message to PDU stream.
+    }
+
     return 0;
+}
+
+
+int32_t pdu_utime(NCODEC* nc, NCodecUtimeOperation op)
+{
+    ABCodecInstance* _nc = (ABCodecInstance*)nc;
+    if (_nc == NULL) return -ENOSTR;
+    if (_nc->c.stream == NULL) return -ENOSR;
+    if (op.simulation_time < 0.0) return -EINVAL;
+    if (op.step_size < 0.0) return -EINVAL;
+
+    int rc = -ENODATA; /* Default return, no action taken. */
+
+    if (op.simulation_time > _nc->simulation_time.value || op.force) {
+        _nc->simulation_time.value = op.simulation_time;
+        _nc->simulation_time.step_size_correction = 0.0;
+        rc = 0;
+    }
+    if (op.step_size > 0) {
+        _nc->simulation_time.step_size = op.step_size;
+        rc = 0;
+    }
+    if (op.broadcast) {
+        _nc->simulation_time.broadcast.request = op.broadcast;
+        _nc->simulation_time.broadcast.force = op.force;
+        rc = 0;
+    }
+    return rc;
 }

--- a/dse/ncodec/examples/ab-codec-fmi/main.c
+++ b/dse/ncodec/examples/ab-codec-fmi/main.c
@@ -72,8 +72,8 @@ int main(void)
     if (rc) return _ncodec_fault("ncodec_seek", rc);
     stream->read(nc, &buffer, &buffer_len, NCODEC_POS_NC);
     fmi_string = ncodec_ascii85_encode((char*)buffer, buffer_len);
-    _log("BUFFER TX", "(%ul)", buffer_len);
-    _log("ASCII85 TX", "(%ul) %s", strlen(fmi_string), fmi_string);
+    _log("BUFFER TX", "(%zu)", buffer_len);
+    _log("ASCII85 TX", "(%zu) %s", strlen(fmi_string), fmi_string);
 
     /* Interact with the FMU for a single Co-Simulation step. */
     rc = ncodec_truncate(nc);
@@ -88,9 +88,9 @@ int main(void)
     if (v[0] == NULL) return _ncodec_fault("fmi2GetString - no data", -ENODATA);
 
     /* Decode the FMI 2 String Variable and inject into the stream buffer. */
-    _log("ASCII85 RX", "(%ul) %s", strlen(v[0]), v[0]);
+    _log("ASCII85 RX", "(%zu) %s", strlen(v[0]), v[0]);
     buffer = (uint8_t*)ncodec_ascii85_decode(v[0], &buffer_len);
-    _log("BUFFER RX", "(%ul)", buffer_len);
+    _log("BUFFER RX", "(%zu)", buffer_len);
     stream->write(nc, buffer, buffer_len);
     free(buffer);
     buffer = NULL;

--- a/dse/ncodec/interface/pdu.h
+++ b/dse/ncodec/interface/pdu.h
@@ -415,10 +415,6 @@ typedef struct NCodecPdu {
         NCodecPduStructMetadata     struct_object;
         NCodecPduFlexrayTransport   flexray;
     } transport;
-
-    /* Simulation Metadata. */
-    double simulation_time;
-    double pdu_time;
 } NCodecPdu;
 
 #endif  // DSE_NCODEC_INTERFACE_PDU_H_

--- a/dse/ncodec/interface/pdu.h
+++ b/dse/ncodec/interface/pdu.h
@@ -10,6 +10,15 @@
 #include <stdlib.h>
 
 
+#if defined(__GNUC__) || defined(__clang__)
+#define NCODEC_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define NCODEC_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#define NCODEC_DEPRECATED(msg)
+#endif
+
+
 /** NCODEC API - PDU/Stream
     =======================
 
@@ -415,6 +424,10 @@ typedef struct NCodecPdu {
         NCodecPduStructMetadata     struct_object;
         NCodecPduFlexrayTransport   flexray;
     } transport;
+
+    /* Simulation Metadata. */
+    double simulation_time NCODEC_DEPRECATED("this field is deprecated");
+    double pdu_time        NCODEC_DEPRECATED("this field is deprecated");
 } NCodecPdu;
 
 #endif  // DSE_NCODEC_INTERFACE_PDU_H_

--- a/tests/cmocka/codec/ab/pdu/CMakeLists.txt
+++ b/tests/cmocka/codec/ab/pdu/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(test_codec_ab_pdu
     test_pdu_can.c
     test_pdu_ip.c
     test_pdu_struct.c
+    test_pdu_flexray.c
     test_pdu_flexray__engine.c
     test_pdu_flexray__state.c
     test_pdu_flexray__startup.c

--- a/tests/cmocka/codec/ab/pdu/__test__.c
+++ b/tests/cmocka/codec/ab/pdu/__test__.c
@@ -11,6 +11,7 @@ extern int run_pdu_tests(void);
 extern int run_pdu_can_tests(void);
 extern int run_pdu_ip_tests(void);
 extern int run_pdu_struct_tests(void);
+extern int run_pdu_flexray_tests(void);
 extern int run_pdu_flexray_engine_tests(void);
 extern int run_pdu_flexray_state_tests(void);
 extern int run_pdu_flexray_startup_tests(void);
@@ -27,6 +28,7 @@ int main()
     rc |= run_pdu_can_tests();
     rc |= run_pdu_ip_tests();
     rc |= run_pdu_struct_tests();
+    rc |= run_pdu_flexray_tests();
     rc |= run_pdu_flexray_engine_tests();
     rc |= run_pdu_flexray_state_tests();
     rc |= run_pdu_flexray_startup_tests();

--- a/tests/cmocka/codec/ab/pdu/test_pdu_can.c
+++ b/tests/cmocka/codec/ab/pdu/test_pdu_can.c
@@ -118,10 +118,9 @@ void test_pdu_transport_can(void** state)
                             });
         assert_int_equal(rc, strlen(greeting));
         size_t len = ncodec_flush(nc);
-        size_t adj =
-            4;  //(tc[i].frame_format ? 0 : 2) + (tc[i].frame_type ? 0: 2);
-        if (tc[i].frame_format || tc[i].frame_type) adj = 4;
-        assert_int_equal(len, 0x8a - adj);
+        size_t adj = 4;
+        if (tc[i].frame_format || tc[i].frame_type) adj = 0;
+        assert_int_equal(len, 0x7a - adj);
 
         // Seek to the start, keeping the content, modify the node_id.
         ncodec_seek(nc, 0, NCODEC_SEEK_SET);

--- a/tests/cmocka/codec/ab/pdu/test_pdu_flexray.c
+++ b/tests/cmocka/codec/ab/pdu/test_pdu_flexray.c
@@ -1,0 +1,186 @@
+// Copyright 2026 Robert Bosch GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <dse/testing.h>
+#include <errno.h>
+#include <stdio.h>
+#include <dse/ncodec/codec.h>
+#include <dse/ncodec/codec/ab/codec.h>
+#include <dse/ncodec/stream/stream.h>
+#include <dse/ncodec/interface/pdu.h>
+
+#define UNUSED(x)     ((void)x)
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define BUFFER_LEN    1024
+
+
+extern NCodecConfigItem codec_stat(NCODEC* nc, int* index);
+extern NCODEC*          ncodec_create(const char* mime_type);
+extern int32_t stream_read(NCODEC* nc, uint8_t** data, size_t* len, int pos_op);
+
+
+typedef struct Mock {
+    NCODEC* nc;
+} Mock;
+
+
+#define MIMETYPE                                                               \
+    "application/x-automotive-bus; "                                           \
+    "interface=stream;type=pdu;schema=fbs;"                                    \
+    "swc_id=4;ecu_id=5;loopback=1"
+
+
+static int test_setup(void** state)
+{
+    Mock* mock = calloc(1, sizeof(Mock));
+    assert_non_null(mock);
+
+    NCodecStreamVTable* stream = ncodec_buffer_stream_create(BUFFER_LEN);
+    mock->nc = (void*)ncodec_open(MIMETYPE, stream);
+    assert_non_null(mock->nc);
+
+    *state = mock;
+    return 0;
+}
+
+
+static int test_teardown(void** state)
+{
+    Mock* mock = *state;
+    if (mock && mock->nc) ncodec_close((void*)mock->nc);
+    if (mock) free(mock);
+
+    return 0;
+}
+
+void test_flexray__utime_api(void** state)
+{
+    Mock*            mock = *state;
+    NCODEC*          nc = mock->nc;
+    ABCodecInstance* abci = (ABCodecInstance*)nc;
+
+    struct TestCase {
+        const char* name;
+        double      simulation_time;
+        double      step_size;
+        int         expected_errno;
+    };
+
+    // Initial conditions.
+    assert_double_equal(abci->simulation_time.value, 0.0, 0.0);
+    assert_double_equal(abci->simulation_time.step_size, 0.0005, 0.0);
+    assert_double_equal(abci->simulation_time.step_size_correction, 0.0, 0.0);
+
+    // clang-format off
+    const struct TestCase cases[] = {
+        { "no data",           0.0,  0.0, ENODATA },
+        { "negative sim time", -0.1, 0.0, EINVAL  },
+        { "negative step",     0.0, -0.1, EINVAL  },
+        { "valid sim time",    0.1,  0.0, 0       },
+        { "valid step",        0.0,  0.1, 0       },
+    };
+    // clang-format on
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        // Entry condition.
+        double sim_time = abci->simulation_time.value;
+        double step_size = abci->simulation_time.step_size;
+        double correction = abci->simulation_time.step_size_correction = 1.0;
+
+        int rc =
+            ncodec_utime(nc, (struct NCodecUtimeOperation){
+                                 .simulation_time = cases[i].simulation_time,
+                                 .step_size = cases[i].step_size });
+
+        if (-rc != cases[i].expected_errno) {
+            fail_msg("case[%zu] (%s): simulation_time=%f, step_size=%f, "
+                     "expected=%d, got=%d",
+                i, cases[i].name, cases[i].simulation_time, cases[i].step_size,
+                cases[i].expected_errno, -rc);
+        }
+
+        if (cases[i].expected_errno == 0) {
+            if (cases[i].simulation_time > 0) {
+                assert_double_equal(
+                    abci->simulation_time.value, cases[i].simulation_time, 0.0);
+                assert_double_equal(
+                    abci->simulation_time.step_size_correction, 0.0, 0.0);
+            }
+            if (cases[i].step_size > 0) {
+                assert_double_equal(
+                    abci->simulation_time.step_size, cases[i].step_size, 0.0);
+            }
+        } else {
+            // Values unchanged.
+            assert_double_equal(abci->simulation_time.value, sim_time, 0.0);
+            assert_double_equal(
+                abci->simulation_time.step_size, step_size, 0.0);
+            assert_double_equal(
+                abci->simulation_time.step_size_correction, correction, 0.0);
+        }
+    }
+}
+
+
+void test_flexray__utime_force(void** state)
+{
+    Mock*            mock = *state;
+    NCODEC*          nc = mock->nc;
+    ABCodecInstance* abci = (ABCodecInstance*)nc;
+
+    struct TestCase {
+        const char* name;
+        double      simulation_time;
+        double      step_size;
+        int         expected_errno;
+    };
+
+    // Initial conditions.
+    assert_double_equal(abci->simulation_time.value, 0.0, 0.0);
+    assert_double_equal(abci->simulation_time.step_size, 0.0005, 0.0);
+    assert_double_equal(abci->simulation_time.step_size_correction, 0.0, 0.0);
+
+    // Push time.
+    abci->simulation_time.value = 1.0;
+    abci->simulation_time.step_size_correction = 1.0;
+
+    // Force a time set (overrides checks).
+    int rc = ncodec_utime(nc,
+        (struct NCodecUtimeOperation){ .simulation_time = 0.5, .force = true });
+    assert_int_equal(rc, 0);
+    assert_double_equal(abci->simulation_time.value, 0.5, 0.0);
+    assert_double_equal(abci->simulation_time.step_size_correction, 0.0, 0.0);
+
+    // Force an invalid time set (should fail).
+    rc = ncodec_utime(nc, (struct NCodecUtimeOperation){
+                              .simulation_time = -1.5, .force = true });
+    assert_int_equal(-rc, EINVAL);
+    assert_double_equal(abci->simulation_time.value, 0.5, 0.0);
+}
+
+
+void test_flexray__utime_broadcast(void** state)
+{
+    skip();
+}
+
+
+void test_flexray__utime_broadcast_force(void** state)
+{
+    skip();
+}
+
+
+int run_pdu_flexray_tests(void)
+{
+    void* s = test_setup;
+    void* t = test_teardown;
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_flexray__utime_api, s, t),
+        cmocka_unit_test_setup_teardown(test_flexray__utime_force, s, t),
+    };
+
+    return cmocka_run_group_tests_name("PDU FLEXRAY", tests, NULL, NULL);
+}

--- a/tests/cmocka/codec/ab/pdu/test_pdu_ip.c
+++ b/tests/cmocka/codec/ab/pdu/test_pdu_ip.c
@@ -82,7 +82,7 @@ void test_pdu_transport_ip__eth(void** state)
     });
     assert_int_equal(rc, strlen(greeting));
     size_t len = ncodec_flush(nc);
-    assert_int_equal(len, 0x9a);
+    assert_int_equal(len, 0x8e);
 
     // Seek to the start, keeping the content.
     ncodec_seek(nc, 0, NCODEC_SEEK_SET);

--- a/tests/cmocka/codec/ab/pdu/test_pdu_struct.c
+++ b/tests/cmocka/codec/ab/pdu/test_pdu_struct.c
@@ -92,7 +92,7 @@ void test_pdu_transport_struct(void** state)
     });
     assert_int_equal(rc, strlen(greeting));
     size_t len = ncodec_flush(nc);
-    assert_int_equal(len, 0xde);
+    assert_int_equal(len, 0xce);
 
     // Seek to the start, keeping the content.
     ncodec_seek(nc, 0, NCODEC_SEEK_SET);

--- a/tests/cmocka/codec/ab/test_codec.c
+++ b/tests/cmocka/codec/ab/test_codec.c
@@ -29,6 +29,7 @@ extern int32_t          pdu_write(NCODEC* nc, NCodecMessage* msg);
 extern int32_t          pdu_read(NCODEC* nc, NCodecMessage* msg);
 extern int32_t          pdu_flush(NCODEC* nc);
 extern int32_t          pdu_truncate(NCODEC* nc);
+extern int32_t          pdu_utime(NCODEC* nc, NCodecUtimeOperation op);
 
 
 NCODEC* ncodec_open(const char* mime_type, NCodecStreamVTable* stream)
@@ -374,6 +375,7 @@ void test_ncodec_can_create_close(void** state)
     assert_ptr_equal(nc->codec.read, can_read);
     assert_ptr_equal(nc->codec.flush, can_flush);
     assert_ptr_equal(nc->codec.truncate, can_truncate);
+    assert_ptr_equal(nc->codec.utime, NULL);
     assert_ptr_equal(nc->codec.close, codec_close);
 
     /* Check the values. */
@@ -427,6 +429,7 @@ void test_ncodec_pdu_create_close(void** state)
     assert_ptr_equal(nc->codec.read, pdu_read);
     assert_ptr_equal(nc->codec.flush, pdu_flush);
     assert_ptr_equal(nc->codec.truncate, pdu_truncate);
+    assert_ptr_equal(nc->codec.utime, pdu_utime);
     assert_ptr_equal(nc->codec.close, codec_close);
 
     /* Check the values. */
@@ -521,6 +524,9 @@ void test_ncodec_call_sequence(void** state)
     _adjust_node_id(nc, "2");
 #define EXPECT_POS 0x66
     assert_int_equal(EXPECT_POS, ncodec_tell(nc));
+    assert_int_equal(
+        -ENOSYS, ncodec_utime(nc, (struct NCodecUtimeOperation){}));
+
 
     /* Read then Write. */
     for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
utime allows setting of simulation_time and step_size.

closes #21 